### PR TITLE
feat: update waypoints app and add storage

### DIFF
--- a/catalog/waypoints/manifest.yaml
+++ b/catalog/waypoints/manifest.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../schema.json
 ---
-version: 0.30.0
+version: 0.30.1
 name: Waypoints (PREALPHA)
 novaOsVersion: ">= 25.10"
 supportsCloud: true
@@ -11,7 +11,7 @@ app:
   name: waypoints
   appIcon: app_icon.png
   containerImage:
-    image: wandelbots.azurecr.io/nova-apps/waypoints:0.30.0
+    image: wandelbots.azurecr.io/nova-apps/waypoints:0.30.1
     secrets:
       - name: pull-secret-wandelbots-azurecr-io
   port: 8003

--- a/catalog/waypoints/manifest.yaml
+++ b/catalog/waypoints/manifest.yaml
@@ -17,4 +17,4 @@ app:
   port: 8003
   storage:
     mountPath: /data
-    capacity: 1Gi
+    capacity: 300Mi

--- a/catalog/waypoints/manifest.yaml
+++ b/catalog/waypoints/manifest.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../schema.json
 ---
-version: 0.30
+version: 0.30.0
 name: Waypoints (PREALPHA)
 novaOsVersion: ">= 25.10"
 supportsCloud: true
@@ -11,7 +11,7 @@ app:
   name: waypoints
   appIcon: app_icon.png
   containerImage:
-    image: wandelbots.azurecr.io/nova-apps/waypoints:0.30
+    image: wandelbots.azurecr.io/nova-apps/waypoints:0.30.0
     secrets:
       - name: pull-secret-wandelbots-azurecr-io
   port: 8003

--- a/catalog/waypoints/manifest.yaml
+++ b/catalog/waypoints/manifest.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../schema.json
 ---
-version: 0.29.2
+version: 0.30
 name: Waypoints (PREALPHA)
 novaOsVersion: ">= 25.10"
 supportsCloud: true
@@ -11,7 +11,10 @@ app:
   name: waypoints
   appIcon: app_icon.png
   containerImage:
-    image: wandelbots.azurecr.io/nova-apps/waypoints:0.29.2
+    image: wandelbots.azurecr.io/nova-apps/waypoints:0.30
     secrets:
       - name: pull-secret-wandelbots-azurecr-io
   port: 8003
+  storage:
+    mountPath: /data
+    capacity: 1Gi


### PR DESCRIPTION
- Bump version from 0.29.2 to 0.30.1 and update container image
- add 300MB volume to persist generated datasets after killed pods and waypoint app upgrades