### PR TITLE
Update novaflow-installer to 2026.6.80

### DIFF
--- a/catalog/_preview/novaflow/manifest.yaml
+++ b/catalog/_preview/novaflow/manifest.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://wandelbotsgmbh.github.io/catalog/schema.json
 ---
-version: 2026.04.05
+version: 2026.6.80
 name: novaflow-installer
 novaOsVersion: ">= 25.3"
 supportsCloud: true
@@ -15,7 +15,7 @@ app:
         - name: PORT
           value: "8000"
     containerImage:
-        image: wandelbots.azurecr.io/apps/novaflow-installer:2026.04.05
+        image: wandelbots.azurecr.io/apps/novaflow-installer:2026.6.80
         secrets:
             - name: pull-secret-wandelbots-azurecr-io
     port: 8000


### PR DESCRIPTION
Point the `novaflow-installer` preview entry at the new installer image
`wandelbots.azurecr.io/apps/novaflow-installer:2026.6.80` and bump the
catalog `version` to `2026.6.80`.

The new installer image carries the revived NovaFlow installer:
- core apps (controlplane / forest / flow) + actions core/general/io/omniverse
- AI Proxy and custom-node install under an Advanced section (opt-in)
- default install version pre-filled to 2026.6.80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
