### PR TITLE
fix(rerun-gateway): point homepage to GitHub repo

### DIFF
--- a/catalog/rerun-gateway/manifest.yaml
+++ b/catalog/rerun-gateway/manifest.yaml
@@ -8,7 +8,7 @@ description: |
   Rerun Gateway is a shared visualization server deployed as a Wandelbots App.
   Any pod in the cluster can log data to it via gRPC, and the web viewer is
   accessible through the platform dashboard.
-homepage: https://code.wabo.run/andrey.sartison/rerun-gateway
+homepage: https://github.com/wandelbotsgmbh/rerun-gateway
 app:
   name: rerun-gateway
   appIcon: app-icon.png


### PR DESCRIPTION
## Summary
The project moved from GitLab (`code.wabo.run/andrey.sartison/rerun-gateway`) to GitHub (`wandelbotsgmbh/rerun-gateway`). Updating the catalog `homepage` to match.

Image registry and version are being updated in #454 — keeping this as a small, separate change so it can land independently.